### PR TITLE
Reduce load balancer replicas

### DIFF
--- a/k8s-manifest-files/deployment.apps_rpc-load-balancer.yaml
+++ b/k8s-manifest-files/deployment.apps_rpc-load-balancer.yaml
@@ -6,13 +6,13 @@ metadata:
   name: rpc-load-balancer
   namespace: olfyi-0001
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: rpc-load-balancer
   strategy:
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:


### PR DESCRIPTION
We don't really need any replicas. Reduce to 2 for simplicity.